### PR TITLE
Prepare 1.1.1

### DIFF
--- a/recipe/menu.json
+++ b/recipe/menu.json
@@ -8,7 +8,7 @@
             "terminal": false,
             "icon": "{{ MENU_DIR }}/anaconda_powershell_prompt.{{ ICON_EXT }}",
             "description": "Launches a PowerShell window with conda activated.",
-            "working_dir": "{{ HOME }}",
+            "working_dir": "%USERPROFILE%",
             "command": [
                 "%WINDIR%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
                 "-ExecutionPolicy",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: anaconda_powershell_prompt
-  version: 1.1.0
+  version: 1.1.1
 
 build:
-  number: 1
+  number: 0
   skip: True  # [not win]
 
 requirements:


### PR DESCRIPTION
`anaconda_powershell_prompt 1.1.1`

**Destination channel:** defaults

### Links

- [PKG-14811](https://anaconda.atlassian.net/browse/PKG-14811) 
- [Upstream repository](https://github.com/AnacondaRecipes/anaconda_powershell_prompt-feedstock)

### Explanation of changes:
- Similar to https://github.com/AnacondaRecipes/anaconda_prompt-feedstock/pull/7
- https://github.com/AnacondaRecipes/anaconda_powershell_prompt-feedstock/pull/5
  - This release resolves an issue for the upcoming MSI installers, since the location of `_conda.exe` is different from regular installers , and adds a check for the environment variable `CONDA_EXE`.
  - Added a check for distinguishing between regular `conda` and `conda-standalone`.


[PKG-14811]: https://anaconda.atlassian.net/browse/PKG-14811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ