### PR TITLE
Use USERPROFILE instead of template parameter for the working directory 

### DIFF
--- a/recipe/menu.json
+++ b/recipe/menu.json
@@ -8,7 +8,7 @@
             "terminal": false,
             "icon": "{{ MENU_DIR }}/anaconda_powershell_prompt.{{ ICON_EXT }}",
             "description": "Launches a PowerShell window with conda activated.",
-            "working_dir": "{{ HOME }}",
+            "working_dir": "%USERPROFILE%",
             "command": [
                 "%WINDIR%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
                 "-ExecutionPolicy",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: anaconda_powershell_prompt
-  version: 1.1.0
+  version: 1.1.1
 
 build:
-  number: 1
+  number: 0
   skip: True  # [not win]
 
 requirements:


### PR DESCRIPTION
anaconda_powershell_prompt v1.1.1

**Destination channel:** defaults

### Explanation of changes:

The `{{ HOME }}` placeholder expands into a rendered path when the shortcut is installed. So, the working directory will be hard-coded to the `%USERPROFILE%` of the user who installs the shortcut. This is not desired for multi-user installations - instead, the prompt should set the working directory of the user who opens the shortcut, not the user who installed it.