### PR TITLE
Fix post-link Python fallback

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,13 +3,14 @@ package:
   version: 1.1.1
 
 build:
-  number: 0
+  number: 1
   skip: True  # [not win]
 
 requirements:
+  run:
+    - menuinst >=2.1.1
   run_constrained:
     - anaconda-navigator >=1.9.8
-    - menuinst >=2.1.1
 
 test:
   commands:

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -20,6 +20,11 @@ IF EXIST "%CONDA_EXE%" (
     )
 )
 
+IF EXIST "%PREFIX%\python.exe" (
+    SET PYTHON_CMD="%PREFIX%\python.exe"
+    GOTO :get_menuinst
+)
+
 IF EXIST "%PREFIX%\_conda.exe" (
     SET PYTHON_CMD="%PREFIX%\_conda.exe" python
     GOTO :get_menuinst


### PR DESCRIPTION
## Summary
- require `menuinst >=2.1.1` at runtime because the Windows post-link script imports it
- let the post-link script use `%PREFIX%\python.exe` before falling back to `_conda.exe`
- bump the build number for the recipe change

## Problem
The Windows post-link script currently depends on conda-specific environment variables or `_conda.exe` to locate Python. Some install flows run link scripts in a complete prefix where `python.exe` is available but `CONDA_PYTHON_EXE` and `CONDA_EXE` are not defined. In that case the script can take the failure path even though the prefix has a usable Python.

`menuinst` is also only listed as a constrained dependency today, but the post-link script imports it unconditionally. Making it a runtime dependency keeps the package metadata aligned with the script behavior.

## Validation
- `git diff --check HEAD~1..HEAD`

## Not run
- Windows package build / post-link execution